### PR TITLE
Add toolbox warning for no input text

### DIFF
--- a/src/lib/toolbox/websites/twitter.ts
+++ b/src/lib/toolbox/websites/twitter.ts
@@ -1,3 +1,4 @@
+import { MAX_Z_INDEX } from '$lib/style';
 import type { ToolboxWebsiteConfig } from '../toolbox.types';
 
 export function createTwitterConfig(): ToolboxWebsiteConfig {
@@ -19,6 +20,11 @@ export function createTwitterConfig(): ToolboxWebsiteConfig {
           container.style.marginTop = '12px';
 
           toolbox.setContainer(container);
+        },
+        afterMount(toolbox) {
+          const container = toolbox.getContainer();
+          const parent = container.parentNode as HTMLElement;
+          parent.style.zIndex = MAX_Z_INDEX;
         },
       },
     ],

--- a/src/lib/toolbox/websites/whatsapp.ts
+++ b/src/lib/toolbox/websites/whatsapp.ts
@@ -1,3 +1,4 @@
+import { MAX_Z_INDEX } from '$lib/style';
 import { sleep } from '$lib/utils';
 import type { ToolboxWebsiteConfig, ToolboxWebsitePlugin } from '../toolbox.types';
 
@@ -20,7 +21,7 @@ function whatsAppContainerPlugin(): ToolboxWebsitePlugin {
     beforeMount(toolbox) {
       const container = document.createElement('div');
       container.style.order = '2';
-      container.style.zIndex = '1';
+      container.style.zIndex = MAX_Z_INDEX;
 
       toolbox.setContainer(container);
     },


### PR DESCRIPTION
A notification is placed on the toolbox indicating that the input is devoid of content.